### PR TITLE
87 add definitions for 'X reproductive shoot system' terms

### DIFF
--- a/src/ontology/components/PPO_plant_structures.owl
+++ b/src/ontology/components/PPO_plant_structures.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/ppo/components/PPO_plant_structures.owl>
-<http://purl.obolibrary.org/obo/ppo/releases/2025-01-27/components/PPO_plant_structures.owl>
-Annotation(owl:versionInfo "2025-01-27")
+<http://purl.obolibrary.org/obo/ppo/releases/2025-02-03/components/PPO_plant_structures.owl>
+Annotation(owl:versionInfo "2025-02-03")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0097207>))
 Declaration(Class(<http://purl.obolibrary.org/obo/PO_0000003>))
@@ -276,18 +276,21 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/PPO_0001025> 
 
 # Class: <http://purl.obolibrary.org/obo/PPO_0001026> (non-senesced reproductive shoot system)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/PPO_0001026> "A reproductive shoot system with at least one non-senesced floral organ.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/PPO_0001026> "non-senesced floral structure")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/PPO_0001026> "non-senesced reproductive shoot system")
 SubClassOf(<http://purl.obolibrary.org/obo/PPO_0001026> <http://purl.obolibrary.org/obo/PO_0025082>)
 
 # Class: <http://purl.obolibrary.org/obo/PPO_0001027> (unopened reproductive shoot system)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/PPO_0001027> "A non-senesced reproductive shoot system in which all floral organs are unopened.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/PPO_0001027> "unopened floral structure")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/PPO_0001027> "unopened reproductive shoot system")
 SubClassOf(<http://purl.obolibrary.org/obo/PPO_0001027> <http://purl.obolibrary.org/obo/PPO_0001026>)
 
 # Class: <http://purl.obolibrary.org/obo/PPO_0001028> (open reproductive shoot system)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/PPO_0001028> "A non-senesced reproductive shoot system with at least one open floral organ.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/PPO_0001028> "open floral structure")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/PPO_0001028> "open reproductive shoot system")
 SubClassOf(<http://purl.obolibrary.org/obo/PPO_0001028> <http://purl.obolibrary.org/obo/PPO_0001026>)
@@ -295,6 +298,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/PPO_0001028> ObjectSomeValuesFrom(<ht
 
 # Class: <http://purl.obolibrary.org/obo/PPO_0001029> (pollen-releasing reproductive shoot system)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/PPO_0001029> "An open reproductive shoot system with at least one pollen-releasing floral organ.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/PPO_0001029> "pollen-releasing floral structure")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/PPO_0001029> "pollen-releasing reproductive shoot system")
 SubClassOf(<http://purl.obolibrary.org/obo/PPO_0001029> <http://purl.obolibrary.org/obo/PPO_0001028>)

--- a/src/templates/PPO_plant_structures.tsv
+++ b/src/templates/PPO_plant_structures.tsv
@@ -28,10 +28,10 @@ PPO:0001022	class	expanding true leaf		PPO:0001013	'true leaf'	A true leaf that 
 PPO:0001023	class	reproductive structure		PO:0009011	PO:'plant structure'	A plant structure that is either a reproductive shoot system or a fruit.	(PO:0025082 OR PO:0009001)				
 PPO:0001024	class	mature seed		PO:0009010	PO:'seed'	A seed that has participated in a seed maturation stage.					
 PPO:0001025	class	floral structure									TRUE
-PPO:0001026	class	non-senesced reproductive shoot system	non-senesced floral structure	PO:0025082	PO:'reproductive shoot system'						
-PPO:0001027	class	unopened reproductive shoot system	unopened floral structure	PPO:0001026	'non-senesced reproductive shoot system'						
-PPO:0001028	class	open reproductive shoot system	open floral structure	PPO:0001026	'non-senesced reproductive shoot system'			(PPO:0000010 some PO:0009046)			
-PPO:0001029	class	pollen-releasing reproductive shoot system	pollen-releasing floral structure	PPO:0001028	'open reproductive shoot system'			(PPO:0000010 some PPO:0001034)			
+PPO:0001026	class	non-senesced reproductive shoot system	non-senesced floral structure	PO:0025082	PO:'reproductive shoot system'	A reproductive shoot system with at least one non-senesced floral organ.					
+PPO:0001027	class	unopened reproductive shoot system	unopened floral structure	PPO:0001026	non-senesced reproductive shoot system'	A non-senesced reproductive shoot system in which all floral organs are unopened.					
+PPO:0001028	class	open reproductive shoot system	open floral structure	PPO:0001026	'non-senesced reproductive shoot system'	A non-senesced reproductive shoot system with at least one open floral organ.		(PPO:0000010 some PO:0009046)			
+PPO:0001029	class	pollen-releasing reproductive shoot system	pollen-releasing floral structure	PPO:0001028	'open reproductive shoot system'	An open reproductive shoot system with at least one pollen-releasing floral organ.		(PPO:0000010 some PPO:0001034)			
 PPO:0001030	class	senesced reproductive shoot system	senesced floral structure	PO:0025082	PO:'reproductive shoot system'	A reproductive shoot system that has completed floral organ senescence.		(PPO:0000010 some PPO:0001035)			
 PPO:0001031	class	non-senesced flower		PO:0009046	PO:'flower'	"A flower in which all the petaloid floral organs floral organ have not completed floral organ senescence. Petaloid floral organs generally are the petals, sepal, or tepals, but may also be floral bracts or petaloid anthers anther.  For scoring phenology in grasses, petaloid floral organs can include lemma, palea or glume, even though a glume is not strictly a floral organ, because it encloses an inflorescence."					
 PPO:0001032	class	unopened flower		PPO:0001031	'non-senesced flower'	A 'non-senesced flower' that is in the 'unopened flower stage'.	(PPO:0001031 that (RO:0000056 some PPO:0007009))				


### PR DESCRIPTION
Related to #87.  Added definitions for:

- non-senesced reproductive shoot system (PPO:0001026)
- unopened reproductive shoot system (PPO:0001027)
- open reproductive shoot system (PPO:0001028)
- pollen-releasing reproductive shoot system (PPO:0001029)

@ramonawalls Will you check if these definitions are correct?